### PR TITLE
Fixed sail module force calculation

### DIFF
--- a/FNPlugin/ModuleSolarSail.cs
+++ b/FNPlugin/ModuleSolarSail.cs
@@ -140,9 +140,15 @@ namespace FNPlugin {
                 if (surfaceTransform != null) {
                     normal = surfaceTransform.forward;
                 }
-				double cosConeAngle = Vector3.Dot (ownsunPosition.normalized (), normal);
-                Vector3d force = normal * cosConeAngle * cosConeAngle;
-                return force * surfaceArea * reflectedPhotonRatio * solarForceAtDistance();
+				// If normal points away from sun, negate so our force is always away from the sun
+				// so that turning the backside towards the sun thrusts correctly
+				if (Vector3d.Dot (normal, ownsunPosition) < 0) {
+					normal = -normal;
+				}
+				// Magnitude of force proportional to cosine-squared of angle between sun-line and normal
+				double cosConeAngle = Vector3.Dot (ownsunPosition.normalized, normal);
+                Vector3d force = normal * cosConeAngle * cosConeAngle * surfaceArea * reflectedPhotonRatio * solarForceAtDistance();
+				return force;
             } else {
                 return Vector3d.zero;
             }

--- a/FNPlugin/ModuleSolarSail.cs
+++ b/FNPlugin/ModuleSolarSail.cs
@@ -135,11 +135,13 @@ namespace FNPlugin {
             if (this.part != null) {
                 Vector3d sunPosition = FlightGlobals.fetch.bodies[0].position;
                 Vector3d ownPosition = this.part.transform.position;
+				Vector3d ownsunPosition = ownPosition - sunPosition;
                 Vector3d normal = this.part.transform.up;
                 if (surfaceTransform != null) {
                     normal = surfaceTransform.forward;
                 }
-                Vector3d force = normal * Vector3d.Dot((ownPosition - sunPosition).normalized, normal);
+				double cosConeAngle = Vector3.Dot (ownsunPosition.normalized (), normal);
+                Vector3d force = normal * cosConeAngle * cosConeAngle;
                 return force * surfaceArea * reflectedPhotonRatio * solarForceAtDistance();
             } else {
                 return Vector3d.zero;


### PR DESCRIPTION
I fixed the sail module so that:
1. The force is always directed away from the sun. In the original, if the sail were oriented so that the backside of the sail was towards the sun, the force on the sail was towards the sun.
2. The magnitude of the force is now equal to the cosine-squared of the angle between the sail normal vector and the sun-line instead of just the cosine. One cosine term comes from the fact that the sail intercepts less light as it turns away from the sun. The second cosine term is because the reflected light glances off the sail when it is tilted, producing less force into the sail.

The end result of this change is that the optimal angle to produce thrust perpendicular to the sun is 35 degrees instead of 45 degrees. In the MechJeb2 SmartA.S.S. module, this angle is a pitch of 55 deg relative the surface of the sun. (Mode: SURF->SURF with HDG: 90 or -90, and PIT: 55).
